### PR TITLE
Adapt to upstream changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,12 @@ rwkv.cpp/bin/test_tiny_rwkv:
 librwkv.a: rwkv.cpp/bin/test_tiny_rwkv
 	cp rwkv.cpp/librwkv.a .
 
-libggml.a: rwkv.cpp/bin/test_tiny_rwkv
-	cp rwkv.cpp/ggml/src/libggml.a .
-
-build: libggml.a librwkv.a
+build: librwkv.a
 
 clean:
 	rm -rfv *.a
 	rm -rfv examples/ai
 	$(MAKE) -C rwkv.cpp clean
 
-examples/ai: librwkv.a libggml.a
+examples/ai: librwkv.a
 	C_INCLUDE_PATH=$(shell pwd) LIBRARY_PATH=$(shell pwd) go build -o examples/ai ./examples

--- a/wrapper.go
+++ b/wrapper.go
@@ -11,7 +11,7 @@ import (
 */
 //#cgo CFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
 //#cgo CPPFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
-//#cgo LDFLAGS: -L./  -lrwkv -lggml -lm -lstdc++
+//#cgo LDFLAGS: -L./  -lrwkv -lm -lstdc++
 // #include "includes.h"
 // #include "ggml.h"
 import "C"


### PR DESCRIPTION
Needed for: https://github.com/go-skynet/LocalAI/issues/411 https://github.com/go-skynet/LocalAI/pull/475

Apparently this is not required anymore with the new rwkv.cpp