### PR TITLE
Fix MacOS build

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -12,7 +12,7 @@ import (
 //#cgo CFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
 //#cgo CPPFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
 //#cgo LDFLAGS: -L./  -lrwkv -lm -lstdc++
-// #cgo darwin LDFLAGS: -framework Accelerate -lcblas
+//#cgo darwin LDFLAGS: -framework Accelerate -lcblas
 // #include "includes.h"
 // #include "ggml.h"
 import "C"

--- a/wrapper.go
+++ b/wrapper.go
@@ -12,6 +12,7 @@ import (
 //#cgo CFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
 //#cgo CPPFLAGS: -I./rwkv.cpp/ggml/include/ggml/ -I./rwkv.cpp -I./
 //#cgo LDFLAGS: -L./  -lrwkv -lm -lstdc++
+// #cgo darwin LDFLAGS: -framework Accelerate -lcblas
 // #include "includes.h"
 // #include "ggml.h"
 import "C"


### PR DESCRIPTION
Fixes:

```
Undefined symbols for architecture x86_64:
  "_cblas_sgemm", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_maxv", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_sve", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_vadd", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_vdiv", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_vmul", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
  "_vDSP_vsub", referenced from:
      _ggml_compute_forward in librwkv.a(ggml.c.o)
```